### PR TITLE
Channel-based light colour models

### DIFF
--- a/channellight/4chlight.go
+++ b/channellight/4chlight.go
@@ -1,0 +1,57 @@
+package channellight
+
+import (
+	"github.com/brutella/hc/service"
+	"math"
+)
+
+type FourChannelColor struct {
+	baseChannelColor
+	Red   int
+	Blue  int
+	Green int
+}
+
+func (this *FourChannelColor) SetColor(color HSLColor) {
+	this.baseChannelColor.SetColor(color)
+	this.calculateRed(color)
+	this.calculateGreen(color)
+	this.calculateBlue(color)
+}
+
+type FourChannelLight struct {
+	baseChannelLight
+	outputColor FourChannelColor
+}
+
+func (this *FourChannelLight) SetColor(lightbulb *service.Lightbulb) {
+	this.baseChannelLight.SetColor(lightbulb)
+	newOutputColor := FourChannelColor{}
+	newOutputColor.baseChannelColor.SetColor(this.targetColor)
+	newOutputColor.calculateRed(this.targetColor)
+	newOutputColor.calculateGreen(this.targetColor)
+	newOutputColor.calculateBlue(this.targetColor)
+	this.outputColor = newOutputColor
+}
+
+func (this *FourChannelLight) GetOutputColor() FourChannelColor {
+	return this.outputColor
+}
+
+func (this *FourChannelColor) scaleSat(saturation float64, base int) int {
+	baseFloat := float64(base)
+	floatVal := (100-saturation)*2.55 + saturation*baseFloat/100
+	return int(math.Floor(floatVal + 0.5))
+}
+
+func (this *FourChannelColor) calculateRed(color HSLColor) {
+	this.Red = this.scaleSat(color.Saturation, multiStop(color.Hue, 120, 240, 300, 60))
+}
+
+func (this *FourChannelColor) calculateGreen(color HSLColor) {
+	this.Green = this.scaleSat(color.Saturation, multiStop(color.Hue, 240, 0, 90, 180))
+}
+
+func (this *FourChannelColor) calculateBlue(color HSLColor) {
+	this.Blue = this.scaleSat(color.Saturation, multiStop(color.Hue, 0, 120, 180, 300))
+}

--- a/channellight/7chlight.go
+++ b/channellight/7chlight.go
@@ -1,0 +1,65 @@
+package channellight
+
+import "github.com/brutella/hc/service"
+
+type SevenChannelColor struct {
+	FourChannelColor
+	Amber int
+	Uv    int
+	White int
+}
+
+func (this *SevenChannelColor) SetColor(color HSLColor) {
+	this.FourChannelColor.SetColor(color)
+	// Red and Green have different ranges to accommodate Amber
+	this.calculateRed(color)
+	this.calculateGreen(color)
+	this.calculateBlue(color)
+	this.calculateWhite(color)
+	this.calculateAmber(color)
+	this.calculateUv(color)
+}
+
+type SevenChannelLight struct {
+	baseChannelLight
+	outputColor SevenChannelColor
+}
+
+func (this *SevenChannelLight) SetColor(lightbulb *service.Lightbulb) {
+	this.baseChannelLight.SetColor(lightbulb)
+	newOutputColor := SevenChannelColor{}
+	newOutputColor.SetColor(this.targetColor)
+	this.outputColor = newOutputColor
+}
+
+func (this *SevenChannelLight) GetOutputColor() SevenChannelColor {
+	return this.outputColor
+}
+
+func (this *SevenChannelColor) calculateRed(color HSLColor) {
+	this.Red = scaleSat(color.Saturation, multiStop(color.Hue, 30, 240, 300, 15))
+}
+
+func (this *SevenChannelColor) calculateGreen(color HSLColor) {
+	this.Green = scaleSat(color.Saturation, multiStop(color.Hue, 240, 30, 90, 180))
+}
+
+func (this *SevenChannelColor) calculateBlue(color HSLColor) {
+	this.Blue = scaleSat(color.Saturation, multiStop(color.Hue, 0, 120, 180, 300))
+}
+
+func (this *SevenChannelColor) calculateWhite(color HSLColor) {
+	if color.Saturation < 50 {
+		this.White = 255
+		return
+	}
+	this.White = linearScale(color.Saturation, 100, 50)
+}
+
+func (this *SevenChannelColor) calculateAmber(color HSLColor) {
+	this.Amber = scaleSat(color.Saturation, multiStop(color.Hue, 120, 0, 15, 60))
+}
+
+func (this *SevenChannelColor) calculateUv(color HSLColor) {
+	this.Uv = scaleSat(color.Saturation, multiStop(color.Hue, 350, 240, 290, 310))
+}

--- a/channellight/base.go
+++ b/channellight/base.go
@@ -1,0 +1,34 @@
+package channellight
+
+import (
+	"github.com/brutella/hc/service"
+	"math"
+)
+
+type baseChannelLight struct {
+	targetColor HSLColor
+}
+
+type baseChannelColor struct {
+	Brightness int
+}
+
+func (this *baseChannelLight) SetColor(lightbulb *service.Lightbulb) {
+	newColor := HSLColor{}
+	newColor.Hue = lightbulb.Hue.GetValue()
+	newColor.Saturation = lightbulb.Saturation.GetValue()
+	newColor.Brightness = lightbulb.Brightness.GetValue()
+	this.targetColor = newColor
+}
+
+func (this *baseChannelLight) GetColor() HSLColor {
+	return this.targetColor
+}
+
+func (this *baseChannelColor) calculateBright(color HSLColor) {
+	this.Brightness = int(math.Floor(0.5 + 2.55*float64(color.Brightness)))
+}
+
+func (this *baseChannelColor) SetColor(color HSLColor) {
+	this.calculateBright(color)
+}

--- a/channellight/helpers.go
+++ b/channellight/helpers.go
@@ -1,0 +1,46 @@
+package channellight
+
+import (
+	"math"
+)
+
+func linearScale(val float64, zeroAt int, maxAt int) int {
+	rangeLen := math.Abs(float64(maxAt - zeroAt))
+	norm := math.Min(math.Max(math.Abs(val-float64(zeroAt))/rangeLen, 0), 1)
+	return int(math.Floor(norm*255 + 0.5))
+}
+
+func isBetween(val float64, stopOne, stopTwo int) bool {
+	useStopOne := float64(stopOne)
+	useStopTwo := float64(stopTwo)
+	if stopOne > stopTwo {
+		if val >= useStopOne || val <= useStopTwo {
+			return true
+		}
+	} else {
+		if val >= useStopOne && val <= useStopTwo {
+			return true
+		}
+	}
+	return false
+}
+
+func multiStop(val float64, zeroOne, zeroTwo, maxOne, maxTwo int) int {
+	if isBetween(val, zeroOne, zeroTwo) {
+		return 0
+	}
+	if isBetween(val, maxOne, maxTwo) {
+		return 255
+	}
+	if isBetween(val, zeroTwo, maxOne) {
+		return linearScale(val, zeroTwo, maxOne)
+	}
+	return linearScale(val, zeroOne, maxTwo)
+}
+
+func scaleSat(saturation float64, baseVal int) int {
+	if saturation > 50 {
+		return baseVal
+	}
+	return int(math.Floor(saturation*float64(baseVal)/50 + 0.5))
+}

--- a/channellight/interface.go
+++ b/channellight/interface.go
@@ -1,0 +1,15 @@
+package channellight
+
+import (
+	"github.com/brutella/hc/service"
+)
+
+type ChannelLight interface {
+	SetColor(lightbulb *service.Lightbulb)
+}
+
+type HSLColor struct {
+	Hue        float64
+	Saturation float64
+	Brightness int
+}

--- a/homekit/experiment.go
+++ b/homekit/experiment.go
@@ -5,6 +5,7 @@
 package main
 
 import (
+	"channellight"
 	"github.com/brutella/hc"
 	"github.com/brutella/hc/accessory"
 	"github.com/brutella/hc/service"
@@ -49,7 +50,7 @@ func main() {
 		convertColorsForLight(light1.Lightbulb)
 	})
 
-	hc.OnTermination(func(){
+	hc.OnTermination(func() {
 		<-t.Stop()
 	})
 
@@ -57,43 +58,25 @@ func main() {
 }
 
 func convertColorsForLight(lightbulb *service.Lightbulb) {
-	hue := lightbulb.Hue.GetValue()
-	saturation := lightbulb.Saturation.GetValue()
-	brightness := lightbulb.Brightness.GetValue()
+	light := channellight.SevenChannelLight{}
+	light.SetColor(lightbulb)
 
-	log.Printf("H: %.0f, S: %.0f, B: %d\n", hue, saturation, brightness)
+	fourchLight := channellight.FourChannelLight{}
+	fourchLight.SetColor(lightbulb)
 
-	red := calculateRed(hue, saturation, brightness)
-	green := calculateGreen(hue, saturation, brightness)
-	blue := calculateBlue(hue, saturation, brightness)
-	white := calculateWhite(hue, saturation, brightness)
-	amber := calculateAmber(hue, saturation, brightness)
-	uv := calculateUv(hue, saturation, brightness)
-
-	log.Printf("R: %d, G: %d, B: %d, W: %d, A: %d, u: %d\n", red, green, blue, white, amber, uv)
 	log.Println("------------------------------------------------------------")
-}
+	log.Println("7 Channel Light")
+	log.Println("------------------------------------------------------------")
+	log.Printf("H: %.0f, S: %.0f, B: %d\n", light.GetColor().Hue, light.GetColor().Saturation, light.GetColor().Brightness)
 
-func calculateRed(hue, saturation float64, brightness int) int {
-	return 0
-}
+	log.Printf("R: %d, G: %d, B: %d, W: %d, A: %d, u: %d, b: %d\n", light.GetOutputColor().Red, light.GetOutputColor().Green, light.GetOutputColor().Blue, light.GetOutputColor().White, light.GetOutputColor().Amber, light.GetOutputColor().Uv, light.GetOutputColor().Brightness)
+	log.Println("------------------------------------------------------------")
 
-func calculateGreen(hue, saturation float64, brightness int) int {
-	return 0
-}
+	log.Println("------------------------------------------------------------")
+	log.Println("4 Channel Light")
+	log.Println("------------------------------------------------------------")
+	log.Printf("H: %.0f, S: %.0f, B: %d\n", fourchLight.GetColor().Hue, fourchLight.GetColor().Saturation, fourchLight.GetColor().Brightness)
 
-func calculateBlue(hue, saturation float64, brightness int) int {
-	return 0
-}
-
-func calculateWhite(hue, saturation float64, brightness int) int {
-	return 0
-}
-
-func calculateAmber(hue, saturation float64, brightness int) int {
-	return 0
-}
-
-func calculateUv(hue, saturation float64, brightness int) int {
-	return 0
+	log.Printf("R: %d, G: %d, B: %d, b: %d\n", fourchLight.GetOutputColor().Red, fourchLight.GetOutputColor().Green, fourchLight.GetOutputColor().Blue, fourchLight.GetOutputColor().Brightness)
+	log.Println("------------------------------------------------------------")
 }


### PR DESCRIPTION
Initial basis for outputting to a variety of light channel settings
- Implement a basic 7-channel (RGB+Amber+White+UV+Brightness) and a basic 4-channel (RGB+Brightness) model
- Actual algorithm is a placeholder, intended to be a very rough approximation
- Implement in a package, since conceptually setting them from HSL is not related to HomeKit