### PR TITLE
Add more channel types

### DIFF
--- a/channellight/4chlight.go
+++ b/channellight/4chlight.go
@@ -45,13 +45,26 @@ func (this *FourChannelColor) scaleSat(saturation float64, base int) int {
 }
 
 func (this *FourChannelColor) calculateRed(color HSLColor) {
-	this.Red = this.scaleSat(color.Saturation, multiStop(color.Hue, 120, 240, 300, 60))
+	this.Red = this.scaleSat(color.Saturation, this.calculateBaseRed(color))
 }
 
 func (this *FourChannelColor) calculateGreen(color HSLColor) {
-	this.Green = this.scaleSat(color.Saturation, multiStop(color.Hue, 240, 0, 90, 180))
+	this.Green = this.scaleSat(color.Saturation, this.calculateBaseGreen(color))
 }
 
 func (this *FourChannelColor) calculateBlue(color HSLColor) {
-	this.Blue = this.scaleSat(color.Saturation, multiStop(color.Hue, 0, 120, 180, 300))
+	this.Blue = this.scaleSat(color.Saturation, this.calculateBaseBlue(color))
+}
+
+
+func (this *FourChannelColor) calculateBaseRed(color HSLColor) int {
+	return multiStop(color.Hue, 120, 240, 300, 60)
+}
+
+func (this *FourChannelColor) calculateBaseGreen(color HSLColor) int {
+	return multiStop(color.Hue, 240, 0, 90, 180)
+}
+
+func (this *FourChannelColor) calculateBaseBlue(color HSLColor) int {
+	return multiStop(color.Hue, 0, 120, 180, 300)
 }

--- a/channellight/5chlight.go
+++ b/channellight/5chlight.go
@@ -1,0 +1,52 @@
+package channellight
+
+import "github.com/brutella/hc/service"
+
+type FiveChannelColor struct {
+	FourChannelColor
+	White int
+}
+
+func (this *FiveChannelColor) SetColor(color HSLColor) {
+	this.FourChannelColor.SetColor(color)
+	this.calculateRed(color)
+	this.calculateGreen(color)
+	this.calculateBlue(color)
+	this.calculateWhite(color)
+}
+
+type FiveChannelLight struct {
+	baseChannelLight
+	outputColor FiveChannelColor
+}
+
+func (this *FiveChannelLight) SetColor(lightbulb *service.Lightbulb) {
+	this.baseChannelLight.SetColor(lightbulb)
+	newOutputColor := FiveChannelColor{}
+	newOutputColor.SetColor(this.targetColor)
+	this.outputColor = newOutputColor
+}
+
+func (this *FiveChannelLight) GetOutputColor() FiveChannelColor {
+	return this.outputColor
+}
+
+func (this *FiveChannelColor) calculateRed(color HSLColor) {
+	this.Red = scaleSat(color.Saturation, this.calculateBaseRed(color))
+}
+
+func (this *FiveChannelColor) calculateGreen(color HSLColor) {
+	this.Green = scaleSat(color.Saturation, this.calculateBaseGreen(color))
+}
+
+func (this *FiveChannelColor) calculateBlue(color HSLColor) {
+	this.Blue = scaleSat(color.Saturation, this.calculateBaseBlue(color))
+}
+
+func (this *FiveChannelColor) calculateWhite(color HSLColor) {
+	if color.Saturation < 50 {
+		this.White = 255
+		return
+	}
+	this.White = linearScale(color.Saturation, 100, 50)
+}

--- a/channellight/5chlight.go
+++ b/channellight/5chlight.go
@@ -1,6 +1,9 @@
 package channellight
 
-import "github.com/brutella/hc/service"
+import (
+	"github.com/brutella/hc/service"
+	"math"
+)
 
 type FiveChannelColor struct {
 	FourChannelColor
@@ -32,15 +35,15 @@ func (this *FiveChannelLight) GetOutputColor() FiveChannelColor {
 }
 
 func (this *FiveChannelColor) calculateRed(color HSLColor) {
-	this.Red = scaleSat(color.Saturation, this.calculateBaseRed(color))
+	this.Red = this.scaleSat(color.Saturation, this.calculateBaseRed(color))
 }
 
 func (this *FiveChannelColor) calculateGreen(color HSLColor) {
-	this.Green = scaleSat(color.Saturation, this.calculateBaseGreen(color))
+	this.Green = this.scaleSat(color.Saturation, this.calculateBaseGreen(color))
 }
 
 func (this *FiveChannelColor) calculateBlue(color HSLColor) {
-	this.Blue = scaleSat(color.Saturation, this.calculateBaseBlue(color))
+	this.Blue = this.scaleSat(color.Saturation, this.calculateBaseBlue(color))
 }
 
 func (this *FiveChannelColor) calculateWhite(color HSLColor) {
@@ -49,4 +52,12 @@ func (this *FiveChannelColor) calculateWhite(color HSLColor) {
 		return
 	}
 	this.White = linearScale(color.Saturation, 100, 50)
+}
+
+
+func (this *FiveChannelColor) scaleSat(saturation float64, baseVal int) int {
+	if saturation > 50 {
+		return baseVal
+	}
+	return int(math.Floor(saturation*float64(baseVal)/50 + 0.5))
 }

--- a/channellight/6chlight.go
+++ b/channellight/6chlight.go
@@ -1,0 +1,44 @@
+package channellight
+
+import "github.com/brutella/hc/service"
+
+type SixChannelColor struct {
+	FiveChannelColor
+	Amber int
+}
+
+func (this *SixChannelColor) SetColor(color HSLColor) {
+	this.FiveChannelColor.SetColor(color)
+	// Red and Green have different ranges to accommodate Amber
+	this.calculateRed(color)
+	this.calculateGreen(color)
+	this.calculateAmber(color)
+}
+
+type SixChannelLight struct {
+	baseChannelLight
+	outputColor SixChannelColor
+}
+
+func (this *SixChannelLight) SetColor(lightbulb *service.Lightbulb) {
+	this.baseChannelLight.SetColor(lightbulb)
+	newOutputColor := SixChannelColor{}
+	newOutputColor.SetColor(this.targetColor)
+	this.outputColor = newOutputColor
+}
+
+func (this *SixChannelLight) GetOutputColor() SixChannelColor {
+	return this.outputColor
+}
+
+func (this *SixChannelColor) calculateRed(color HSLColor) {
+	this.Red = scaleSat(color.Saturation, multiStop(color.Hue, 30, 240, 300, 15))
+}
+
+func (this *SixChannelColor) calculateGreen(color HSLColor) {
+	this.Green = scaleSat(color.Saturation, multiStop(color.Hue, 240, 30, 90, 180))
+}
+
+func (this *SixChannelColor) calculateAmber(color HSLColor) {
+	this.Amber = scaleSat(color.Saturation, multiStop(color.Hue, 120, 0, 15, 70))
+}

--- a/channellight/6chlight.go
+++ b/channellight/6chlight.go
@@ -32,13 +32,13 @@ func (this *SixChannelLight) GetOutputColor() SixChannelColor {
 }
 
 func (this *SixChannelColor) calculateRed(color HSLColor) {
-	this.Red = scaleSat(color.Saturation, multiStop(color.Hue, 30, 240, 300, 15))
+	this.Red = this.scaleSat(color.Saturation, multiStop(color.Hue, 30, 240, 300, 15))
 }
 
 func (this *SixChannelColor) calculateGreen(color HSLColor) {
-	this.Green = scaleSat(color.Saturation, multiStop(color.Hue, 240, 30, 90, 180))
+	this.Green = this.scaleSat(color.Saturation, multiStop(color.Hue, 240, 30, 90, 180))
 }
 
 func (this *SixChannelColor) calculateAmber(color HSLColor) {
-	this.Amber = scaleSat(color.Saturation, multiStop(color.Hue, 120, 0, 15, 70))
+	this.Amber = this.scaleSat(color.Saturation, multiStop(color.Hue, 120, 0, 15, 70))
 }

--- a/channellight/7chlight.go
+++ b/channellight/7chlight.go
@@ -29,5 +29,5 @@ func (this *SevenChannelLight) GetOutputColor() SevenChannelColor {
 }
 
 func (this *SevenChannelColor) calculateUv(color HSLColor) {
-	this.Uv = scaleSat(color.Saturation, multiStop(color.Hue, 350, 240, 290, 310))
+	this.Uv = this.scaleSat(color.Saturation, multiStop(color.Hue, 350, 240, 290, 310))
 }

--- a/channellight/7chlight.go
+++ b/channellight/7chlight.go
@@ -3,20 +3,12 @@ package channellight
 import "github.com/brutella/hc/service"
 
 type SevenChannelColor struct {
-	FourChannelColor
-	Amber int
+	SixChannelColor
 	Uv    int
-	White int
 }
 
 func (this *SevenChannelColor) SetColor(color HSLColor) {
-	this.FourChannelColor.SetColor(color)
-	// Red and Green have different ranges to accommodate Amber
-	this.calculateRed(color)
-	this.calculateGreen(color)
-	this.calculateBlue(color)
-	this.calculateWhite(color)
-	this.calculateAmber(color)
+	this.SixChannelColor.SetColor(color)
 	this.calculateUv(color)
 }
 
@@ -34,30 +26,6 @@ func (this *SevenChannelLight) SetColor(lightbulb *service.Lightbulb) {
 
 func (this *SevenChannelLight) GetOutputColor() SevenChannelColor {
 	return this.outputColor
-}
-
-func (this *SevenChannelColor) calculateRed(color HSLColor) {
-	this.Red = scaleSat(color.Saturation, multiStop(color.Hue, 30, 240, 300, 15))
-}
-
-func (this *SevenChannelColor) calculateGreen(color HSLColor) {
-	this.Green = scaleSat(color.Saturation, multiStop(color.Hue, 240, 30, 90, 180))
-}
-
-func (this *SevenChannelColor) calculateBlue(color HSLColor) {
-	this.Blue = scaleSat(color.Saturation, multiStop(color.Hue, 0, 120, 180, 300))
-}
-
-func (this *SevenChannelColor) calculateWhite(color HSLColor) {
-	if color.Saturation < 50 {
-		this.White = 255
-		return
-	}
-	this.White = linearScale(color.Saturation, 100, 50)
-}
-
-func (this *SevenChannelColor) calculateAmber(color HSLColor) {
-	this.Amber = scaleSat(color.Saturation, multiStop(color.Hue, 120, 0, 15, 60))
 }
 
 func (this *SevenChannelColor) calculateUv(color HSLColor) {

--- a/channellight/helpers.go
+++ b/channellight/helpers.go
@@ -37,10 +37,3 @@ func multiStop(val float64, zeroOne, zeroTwo, maxOne, maxTwo int) int {
 	}
 	return linearScale(val, zeroOne, maxTwo)
 }
-
-func scaleSat(saturation float64, baseVal int) int {
-	if saturation > 50 {
-		return baseVal
-	}
-	return int(math.Floor(saturation*float64(baseVal)/50 + 0.5))
-}

--- a/homekit/experiment.go
+++ b/homekit/experiment.go
@@ -64,19 +64,39 @@ func convertColorsForLight(lightbulb *service.Lightbulb) {
 	fourchLight := channellight.FourChannelLight{}
 	fourchLight.SetColor(lightbulb)
 
+	fivechLight := channellight.FiveChannelLight{}
+	fivechLight.SetColor(lightbulb)
+
+	sixchLight := channellight.SixChannelLight{}
+	sixchLight.SetColor(lightbulb)
+
+	sevenChColor := light.GetOutputColor()
+	sixChColor := sixchLight.GetOutputColor()
+	fiveChColor := fivechLight.GetOutputColor()
+	fourChColor := fourchLight.GetOutputColor()
+
+	inColor := light.GetColor()
+
+	log.Println("------------------------------------------------------------")
+	log.Println("HSL Input")
+	log.Println("------------------------------------------------------------")
+	log.Printf("H: %.0f, S: %.0f, B: %d\n", inColor.Hue, inColor.Saturation, inColor.Brightness)
+
 	log.Println("------------------------------------------------------------")
 	log.Println("7 Channel Light")
 	log.Println("------------------------------------------------------------")
-	log.Printf("H: %.0f, S: %.0f, B: %d\n", light.GetColor().Hue, light.GetColor().Saturation, light.GetColor().Brightness)
-
-	log.Printf("R: %d, G: %d, B: %d, W: %d, A: %d, u: %d, b: %d\n", light.GetOutputColor().Red, light.GetOutputColor().Green, light.GetOutputColor().Blue, light.GetOutputColor().White, light.GetOutputColor().Amber, light.GetOutputColor().Uv, light.GetOutputColor().Brightness)
+	log.Printf("R: %d, G: %d, B: %d, W: %d, A: %d, u: %d, b: %d\n", sevenChColor.Red, sevenChColor.Green, sevenChColor.Blue, sevenChColor.White, sevenChColor.Amber, sevenChColor.Uv, sevenChColor.Brightness)
 	log.Println("------------------------------------------------------------")
-
+	log.Println("6 Channel Light")
+	log.Println("------------------------------------------------------------")
+	log.Printf("R: %d, G: %d, B: %d, W: %d, A:%d, b: %d\n", sixChColor.Red, sixChColor.Green, sixChColor.Blue, sixChColor.White, sixChColor.Amber, sixChColor.Brightness)
+	log.Println("------------------------------------------------------------")
+	log.Println("5 Channel Light")
+	log.Println("------------------------------------------------------------")
+	log.Printf("R: %d, G: %d, B: %d, W: %d, b: %d\n", fiveChColor.Red, fiveChColor.Green, fiveChColor.Blue, fiveChColor.White, fiveChColor.Brightness)
 	log.Println("------------------------------------------------------------")
 	log.Println("4 Channel Light")
 	log.Println("------------------------------------------------------------")
-	log.Printf("H: %.0f, S: %.0f, B: %d\n", fourchLight.GetColor().Hue, fourchLight.GetColor().Saturation, fourchLight.GetColor().Brightness)
-
-	log.Printf("R: %d, G: %d, B: %d, b: %d\n", fourchLight.GetOutputColor().Red, fourchLight.GetOutputColor().Green, fourchLight.GetOutputColor().Blue, fourchLight.GetOutputColor().Brightness)
+	log.Printf("R: %d, G: %d, B: %d, b: %d\n", fourChColor.Red, fourChColor.Green, fourChColor.Blue, fourChColor.Brightness)
 	log.Println("------------------------------------------------------------")
 }


### PR DESCRIPTION
Basic implementation for 5-channel and 6-channel lights
Readjust other parts to maximise reuse, and only redefine 'magic' values where they differ